### PR TITLE
Bugfix to subsetByLeaf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,9 @@ Authors@R:
     c(person("Ruizhu", "Huang", email = "ruizhuRH@gmail.com",
       role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3285-1945")),
       person("Felix G.M.", "Ernst", email = "felix.gm.ernst@outlook.com",
-      role = c("ctb"), comment = c(ORCID = "0000-0001-5064-0928")))
+      role = c("ctb"), comment = c(ORCID = "0000-0001-5064-0928")),
+      person(given = "Tuomas", family = "Borman", role = c("ctb"),
+             comment = c(ORCID = "0000-0002-8563-8884")))
 Description: TreeSummarizedExperiment has extended SingleCellExperiment to 
     include hierarchical information on the rows or columns of the rectangular 
     data.

--- a/R/internal_utils.R
+++ b/R/internal_utils.R
@@ -610,12 +610,13 @@
     names(new_dimTree) <- nam
     for (i in nam) {
         ti <- new_dimTree[[i]]
+        link_i <- dimLink[dimLink[["whichTree"]] == i, "nodeLab"]
         if (dim == "row") {
-            x <- changeTree(x = x, rowTree = ti, whichRowTree = i, 
-                            rowNodeLab = ti$tip.label)
+            x <- changeTree(x = x, rowTree = ti, whichRowTree = i,
+                            rowNodeLab = link_i)
         } else {
-            x <- changeTree(x = x, colTree = ti, whichColTree = i, 
-                            colNodeLab = ti$tip.label)
+            x <- changeTree(x = x, colTree = ti, whichColTree = i,
+                            colNodeLab = link_i)
         }
     }
     


### PR DESCRIPTION
Hello @markrobinsonuzh !

As pointed out in the issue https://github.com/markrobinsonuzh/TreeSummarizedExperiment/issues/83, `subsetByLeaf()` mixes up the linkages between tree nodes and rows. This is because the `rowNodeLab` in `changeTree()` must include corresponding node for each row, i.e. vector where 1st element denotes the corresponding node for row 1 and so forth.

`ti$tip.label` does not ensure that the order of the linkages is correct which is causing the error. See the following example.

```
library(miaViz)
library(patchwork)

data("Tengeler2020")
tse <- Tengeler2020

# Subset data
tse <- tse[1:20, ]

# This works. The function prunes the tree internally
p1 <- plotRowTree(tse, edge_colour_by="Phylum", tip_colour_by="Order")
# Prune tree with subsetByLeaf mixes up links
tse <- subsetByLeaf(tse, rowLinks(tse)[[1]])

p2 <- plotRowTree(tse, edge_colour_by="Phylum", tip_colour_by="Order")

p1 + p2
```
![image](https://github.com/user-attachments/assets/b2beba9b-c72e-43a6-8653-2324334ba581)

This PR the error.

-Tuomas
